### PR TITLE
Add note that native code is not actually a public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # Elm native module
 
+**This is highly discouraged, and will not be possible in future versions of Elm.**
+
+The core Elm libraries need access to JavaScript to expose HTTP in Elm (for example) but this is not a public API. It is not intended for public use. It can change dramatically from release to release. It is not permitted in published packages. And again, in future versions, it will not be accessible.
+
+In summary, it is better to figure out how to structure code such that ports will be a good option. If you cannot achieve what you want after asking around on Slack, the best path may be to circle back around to Elm later when more of the Web Platform is covered to your liking.
+
+<br>
+
+<br>
+
+<br>
+
+<br>
+
+
+
 ## What?
 
 This is an example of how to do elm native modules for elm 0.18. It


### PR DESCRIPTION
It is not documented because it is not a public API.

I am in a weird position because people think "Why are there no docs for this?" and I think "How do you document an implementation detail that is not intended for public use?"

Anyway, I hope adding this note will help people evaluate the time they want to spend on this path.